### PR TITLE
Melhorado performance do método generateID

### DIFF
--- a/grape.js
+++ b/grape.js
@@ -55,7 +55,7 @@ function grape () {
   }
 
   this.generateID = function () {
-    var id = Date.now() + Math.floor(Math.random() * (9999 - 1000)) + 1000;
+    var id = Date.now() + Math.floor(Math.random() * 8999);
     return id;
   }
 }


### PR DESCRIPTION
No método generateID havia uma operação aritmética estática (9999 - 1000), onde o resultado sempre seria o mesmo, foi alterado para o valor fixo para diminui um cálculo do processador, foi removido a operação de soma no final (+ 1000) também por não alterar de fato o valor do resultado (que já é o valor de Date.now() somado a um valor randômico entre 0 e 8999 (que neste caso pode ser alterado par a 9999, só para aumentar em 1000 o range de possíveis valores)